### PR TITLE
 Ajout d'une variable pour «optionnaliser» la gestion du repository 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,6 @@ php_version: '7.4'
 
 # For Debian OSes only.
 php_versions_install_recommends: false
+
+# Cette variable sert à piloterla configuration des repos APT
+config_system: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,10 +47,6 @@
     name: dirmngr
     state: present
 
-- name: Add repository for PHP versions (Ubuntu).
-  apt_repository: repo='ppa:ondrej/php'
-  when: ansible_distribution == "Ubuntu"
-
 # Debian-specific tasks.
 - name: Add dependencies for PHP versions (Debian).
   apt:
@@ -58,27 +54,27 @@
       - apt-transport-https
       - ca-certificates
     state: present
-  when: ansible_distribution == "Debian"
+  when:
+    - config_system
 
 - name: Add Ondrej Sury's apt key (Debian).
   apt_key:
     url: https://packages.sury.org/php/apt.gpg
     id: 15058500A0235D97F5D10063B188E2B695BD4743
     state: present
-  when: ansible_distribution == "Debian"
+  when: config_system | bool
 
 - name: Add Ondrej Sury's repo (Debian).
   apt_repository:
     repo: "deb https://packages.sury.org/php/ {{ ansible_distribution_release }} main"
     state: present
   register: php_ondrej_debian_repo
-  when: ansible_distribution == "Debian"
+  when: config_system | bool
 
 - name: Update apt caches after repo is added (Debian).
   apt: update_cache=true
   when:
     - php_ondrej_debian_repo.changed
-    - ansible_distribution == "Debian"
   tags: ['skip_ansible_lint']
 
 - name: Purge PHP version packages (besides the currently chosen php_version).


### PR DESCRIPTION
Pour pouvoir déployer les applications chez des clients qui gérent eux-même les repository debian, on rend optionnel la création et la gestion des sources-list dans nos roles ansibles.