### PR TITLE
Ajout des versions de PHP à supprimer avant d'installer 

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -47,3 +47,12 @@ php_versions_debian:
   - php8.0-common
   - php8.1-common
   - php8.2-common
+  - php8.3-common
+  - php8.4-common
+  - php8.5-common
+  - php8.6-common
+  - php8.7-common
+  - php8.8-common
+  - php8.9-common
+  - php9.0-common
+  - php9.1-common


### PR DESCRIPTION
## Problème

L'installation de PHP 8.5 ne supprime pas le PHP 8.3 déjà installé.

## Cause

La variable Ansible `php_versions_debian` contenu dans ce rôle et qui liste toutes les versions de PHP à supprimer avant d'installer la nouvelle, n'est plus à jour.

Cela fait suite à #1 

## Solution

Ajout de toutes les versions manquantes, ainsi que celles n'existant pas encore afin d'être tranquille pour un moment.

C'est bourrin, mais c'est la logique du rôle et il s'exécute correctement même avec ces versions futures.